### PR TITLE
Fix for canvas error during installation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "study": "./bin/index.js",
     "lenses": "./bin/index.js"
   },
+  "overrides": {
+    "graphviz-cli": {
+      "canvas": "^2.11.2"
+    }
+  },
   "dependencies": {
     "@gerhobbelt/gitignore-parser": "^0.2.0-8",
     "@mapbox/node-pre-gyp": "^1.0.5",


### PR DESCRIPTION
With this property added, we instuct the `graphviz-cli` package, which requries `canvas` package, to install version 2.11.2 rather than 2.8.0 that does not have prebuild support for NodeJS versions 19 and higher.